### PR TITLE
Minor correction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ nvm use node
 ```
 git clone git@github.com:ahoog42/ios-triage.git
 
-cd ios-install
+cd ios-triage
 npm install
 npm link
 ```


### PR DESCRIPTION
The default file path of the git repo is ios-triage, not ios-install